### PR TITLE
feat(web): 支持在设置中配置第三方 AI 模型服务

### DIFF
--- a/password-xl-web/src/api/password-xl-api.ts
+++ b/password-xl-web/src/api/password-xl-api.ts
@@ -2,10 +2,9 @@ import {randomPassword} from "@/utils/global.js";
 import {decryptAES, encryptAES, encryptRSA} from "@/utils/security.js";
 import axios from "axios";
 import config from "@/config";
+import {useSettingStore} from "@/stores/SettingStore.ts";
 
-
-export const extractPasswordApi = async (text: string, batch: boolean = false) => {
-    console.log('AI解析密码')
+const requestOfficialAiApi = async (text: string, batch: boolean = false) => {
     // 随机一个密码作为服务端对称加密的密钥
     let key = randomPassword({length: 16, number: true, lowercase: true, uppercase: true, symbol: false})
 
@@ -24,7 +23,6 @@ export const extractPasswordApi = async (text: string, batch: boolean = false) =
             data: encryptData,
             batch: batch,
         }
-        console.log("AI解析发送请求")
         axios.post(config.apiServer + '/extractPassword', body).then((res) => {
             let data: any = res.data
             if (data.code !== 200) {
@@ -34,9 +32,59 @@ export const extractPasswordApi = async (text: string, batch: boolean = false) =
 
             let password = decryptAES(key, data.data)
             resolve(password)
-        }).catch((err) => {
-            console.log('提取密码失败', err)
+        }).catch(() => {
             reject('提取密码失败')
         })
+    })
+}
+
+const requestThirdPartyAiApi = async (text: string, batch: boolean = false) => {
+    const settingStore = useSettingStore()
+    const aiModel = settingStore.setting.aiModel
+
+    if (!aiModel.baseUrl || !aiModel.apiKey || !aiModel.model) {
+        return Promise.reject('请先在设置中完善AI模型配置')
+    }
+
+    const prompt = batch
+        ? `请从以下文本中提取所有密码信息，并严格返回JSON数组字符串。每一项格式为：{"name":"","address":"","username":"","password":"","remark":""}。\n如果某字段不存在请填空字符串，不要返回markdown代码块，不要附加解释。\n文本内容：\n${text}`
+        : `请从以下文本中提取1条密码信息，并严格返回JSON对象字符串，格式为：{"name":"","address":"","username":"","password":"","remark":""}。\n如果某字段不存在请填空字符串，不要返回markdown代码块，不要附加解释。\n文本内容：\n${text}`
+
+    const baseUrl = aiModel.baseUrl.endsWith('/') ? aiModel.baseUrl.slice(0, -1) : aiModel.baseUrl
+    const response = await axios.post(`${baseUrl}/chat/completions`, {
+        model: aiModel.model,
+        messages: [
+            {
+                role: 'user',
+                content: prompt,
+            }
+        ],
+        temperature: 0,
+    }, {
+        headers: {
+            Authorization: `Bearer ${aiModel.apiKey}`,
+            'Content-Type': 'application/json',
+        }
+    })
+
+    const content = response?.data?.choices?.[0]?.message?.content
+    if (!content) {
+        return Promise.reject('AI模型返回内容为空')
+    }
+
+    return content.trim()
+}
+
+export const extractPasswordApi = async (text: string, batch: boolean = false) => {
+    console.log('AI解析密码')
+    const settingStore = useSettingStore()
+    const provider = settingStore.setting.aiModel.provider
+
+    if (provider === 'official') {
+        return requestOfficialAiApi(text, batch)
+    }
+
+    return requestThirdPartyAiApi(text, batch).catch(() => {
+        return Promise.reject('提取密码失败，请检查AI模型配置')
     })
 }

--- a/password-xl-web/src/components/common/setting/AiImport.vue
+++ b/password-xl-web/src/components/common/setting/AiImport.vue
@@ -17,6 +17,13 @@ const refStore = useRefStore()
 
 const passwordText = ref('')
 
+
+const normalizeAiResponse = (resp: string) => {
+  const content = resp.trim()
+  const markdownMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  return markdownMatch ? markdownMatch[1].trim() : content
+}
+
 // 存储解析后的密码数组
 const importPasswords: Ref<Array<Password>> = ref([]);
 
@@ -92,7 +99,7 @@ const startAnalysis = () => {
   extractPasswordApi(passwordText.value, true).then((resp: any) => {
     step.value = 3
     console.log('AI解析，解析密码完成')
-    const passwordArray = JSON.parse(resp)
+    const passwordArray = JSON.parse(normalizeAiResponse(resp))
     for (let i = 0; i < passwordArray.length; i++) {
       importPasswords.value.push({
         id: incrId(),

--- a/password-xl-web/src/components/common/setting/Setting.vue
+++ b/password-xl-web/src/components/common/setting/Setting.vue
@@ -2,7 +2,7 @@
 <script lang="ts" setup>
 
 import {displaySize, supportAI} from "@/utils/global.ts";
-import {GenerateRule, Password, Sort, TopicMode} from "@/types";
+import {AiModelSetting, GenerateRule, Password, Sort, TopicMode} from "@/types";
 import {usePasswordStore} from "@/stores/PasswordStore.ts";
 import {useRefStore} from "@/stores/RefStore.ts";
 import {browserFingerprint, encryptAES} from "@/utils/security.ts";
@@ -215,6 +215,15 @@ watch(() => settingStore.setting.enableAiAdd, (newValue: boolean) => {
   if (!settingStore.visSetting) return
   console.log('AI创建密码设置变更:', newValue)
   passwordStore.passwordManager.syncSetting()
+})
+
+// 监听AI模型配置变更
+watch(() => settingStore.setting.aiModel, (newValue: AiModelSetting) => {
+  if (!settingStore.visSetting) return
+  console.log('AI模型配置变更:', newValue)
+  passwordStore.passwordManager.syncSetting()
+}, {
+  deep: true
 })
 
 // 监听密码列表中显示时间设置变更
@@ -451,6 +460,30 @@ const isAndroid = () => {
               <el-divider class="function-line"/>
               <el-text style="text-indent: 10px" tag="p" type="info">
                 在首页启用AI创建密码，AI创建可以把包含账号信息的文本解析成结构化的密码。
+              </el-text>
+            </div>
+            <div class="function-div" v-if="supportAI()">
+              <div class="function-header" style="align-items: flex-start;flex-direction: column;">
+                <el-text tag="b">AI模型服务</el-text>
+                <div style="margin-top: 10px;width: 100%">
+                  <el-select v-model="settingStore.setting.aiModel.provider" size="small" style="width: 180px">
+                    <el-option label="官方服务（默认）" value="official"></el-option>
+                    <el-option label="第三方OpenAI兼容" value="openai-compatible"></el-option>
+                  </el-select>
+                </div>
+                <div v-if="settingStore.setting.aiModel.provider !== 'official'" style="margin-top: 10px;width: 100%">
+                  <el-input v-model="settingStore.setting.aiModel.baseUrl" placeholder="Base URL，例如：https://api.openai.com/v1" size="small"></el-input>
+                </div>
+                <div v-if="settingStore.setting.aiModel.provider !== 'official'" style="margin-top: 10px;width: 100%">
+                  <el-input v-model="settingStore.setting.aiModel.apiKey" placeholder="API Key" show-password size="small"></el-input>
+                </div>
+                <div v-if="settingStore.setting.aiModel.provider !== 'official'" style="margin-top: 10px;width: 100%">
+                  <el-input v-model="settingStore.setting.aiModel.model" placeholder="模型名称，例如：gpt-4o-mini / Qwen/Qwen2.5-72B-Instruct" size="small"></el-input>
+                </div>
+              </div>
+              <el-divider class="function-line"/>
+              <el-text style="text-indent: 10px" tag="p" type="info">
+                默认使用官方AI服务。若切换到第三方OpenAI兼容服务，可配置OpenAI、硅基流动等支持 /chat/completions 的模型服务。
               </el-text>
             </div>
             <div class="function-div">

--- a/password-xl-web/src/components/index/AiAddPassword.vue
+++ b/password-xl-web/src/components/index/AiAddPassword.vue
@@ -11,6 +11,13 @@ const alertInfo = ref({
   text: ''
 })
 
+
+const normalizeAiResponse = (resp: string) => {
+  const content = resp.trim()
+  const markdownMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  return markdownMatch ? markdownMatch[1].trim() : content
+}
+
 const show = () => {
   alertInfo.value.text = ''
   alertInfo.value.loading = false
@@ -21,7 +28,7 @@ const extractPassword = () => {
   alertInfo.value.loading = true
   extractPasswordApi(alertInfo.value.text).then((resp: any) => {
     refStore.passwordFormRef.addPasswordForm()
-    refStore.passwordFormRef.setPasswordForm(JSON.parse(resp))
+    refStore.passwordFormRef.setPasswordForm(JSON.parse(normalizeAiResponse(resp)))
     alertInfo.value.vis = false
     alertInfo.value.loading = false
     alertInfo.value.text = ''

--- a/password-xl-web/src/stores/SettingStore.ts
+++ b/password-xl-web/src/stores/SettingStore.ts
@@ -68,6 +68,13 @@ export const useSettingStore = defineStore('settingStore', {
                 dynamicBackground: true,
                 // 密码颜色
                 passwordColor: false,
+                // AI模型配置
+                aiModel: {
+                    provider: 'official',
+                    baseUrl: '',
+                    apiKey: '',
+                    model: '',
+                },
             }
         }
     }

--- a/password-xl-web/src/types/index.ts
+++ b/password-xl-web/src/types/index.ts
@@ -70,6 +70,13 @@ export interface GenerateRule {
     symbol: boolean,// 是否使用特殊符号
 }
 
+export interface AiModelSetting {
+    provider: string,
+    baseUrl: string,
+    apiKey: string,
+    model: string,
+}
+
 // 设置
 export interface Setting {
     sortField: keyof Password, // 排序字段
@@ -96,6 +103,7 @@ export interface Setting {
     bgColors: Array<string>, // 背景色
     dynamicBackground: boolean, // 动态背景图
     passwordColor: boolean, // 密码颜色
+    aiModel: AiModelSetting, // AI模型配置
 }
 
 // 密码管理器


### PR DESCRIPTION
### Motivation
- 目前 AI 创建/批量导入始终调用官方 AI 服务，需支持在设置中配置私有或第三方 OpenAI 兼容模型（如 OpenAI、硅基流动等），默认仍使用官方服务以保持兼容性。

### Description
- 新增类型 `AiModelSetting` 并在 `Setting` 中添加 `aiModel` 字段，默认 `provider` 为 `official`，并在默认设置中初始化该结构（`src/types/index.ts`, `src/stores/SettingStore.ts`）。
- 在设置页「功能管理」增加 `AI模型服务` UI，可选择 `official` 或 `openai-compatible`，并在选择第三方时填写 `Base URL`、`API Key`、`Model`（`src/components/common/setting/Setting.vue`）。
- 将 AI 解析逻辑拆分为 `requestOfficialAiApi`（沿用原有加密上报 `/extractPassword`）和 `requestThirdPartyAiApi`（基于设置中的 `baseUrl/apiKey/model` 调用 OpenAI 兼容的 `/chat/completions`），并在 `extractPasswordApi` 中根据 `aiModel.provider` 路由请求（`src/api/password-xl-api.ts`）。
- 对 AI 创建与 AI 批量导入的返回进行规范化处理，自动剥离可能包含的 ```json ``` 代码块再 `JSON.parse`，以提高兼容性（`src/components/index/AiAddPassword.vue`, `src/components/common/setting/AiImport.vue`）。

### Testing
- 运行 `npm run build`（在 `password-xl-web`）构建通过且无编译错误。 (成功)
- 启动开发服务器 `npm run start -- --host 0.0.0.0 --port 4173` 并用浏览器脚本访问页面获取截图以验证 UI 变更（已生成截图）。 (成功)
- 未新增单元测试，主要验证为构建与页面可访问性检查。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9c5216e483209b74c59b8d26c5d2)